### PR TITLE
Linux 32 bit compilation fixes

### DIFF
--- a/contrib/timelord/timelord.c
+++ b/contrib/timelord/timelord.c
@@ -38,7 +38,6 @@
 #endif /* HAVE_SGTTY_H */
 #include <errno.h>
 #include <signal.h>
-#pragma warn "testing 123"
 #include <atalk/logger.h>
 #include <stdio.h>
 #include <string.h>

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -579,7 +579,7 @@ int getmetadata(struct vol *vol,
 			}
 			break;
 		case FILPBIT_EXTDFLEN:
-			aint = htonl(st->st_size >> 32);
+			aint = htonl((unsigned long long)st->st_size >> 32);
 			memcpy(data, &aint, sizeof(aint));
 			data += sizeof(aint);
 			aint = htonl(st->st_size);
@@ -589,7 +589,7 @@ int getmetadata(struct vol *vol,
 		case FILPBIT_EXTRFLEN:
 			aint = 0;
 			if (adp)
-				aint = htonl(adp->ad_rlen >> 32);
+				aint = htonl((unsigned long long)adp->ad_rlen >> 32);
 			memcpy(data, &aint, sizeof(aint));
 			data += sizeof(aint);
 			if (adp)

--- a/etc/afpd/fork.c
+++ b/etc/afpd/fork.c
@@ -104,7 +104,7 @@ static off_t get_off_t(char **ibuf, int is64)
 	if (is64) {
 		memcpy(&temp, *ibuf, sizeof(temp));
 		*ibuf += sizeof(temp);
-		ret = ntohl(temp) | (ret << 32);
+		ret = ntohl(temp) | ((unsigned long long) ret << 32);
 	} else {
 		ret = (int) ret;	/* sign extend */
 	}
@@ -119,7 +119,7 @@ static int set_off_t(off_t offset, char *rbuf, int is64)
 
 	ret = 0;
 	if (is64) {
-		temp = htonl(offset >> 32);
+		temp = htonl((unsigned long long) offset >> 32);
 		memcpy(rbuf, &temp, sizeof(temp));
 		rbuf += sizeof(temp);
 		ret = sizeof(temp);

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -509,7 +509,7 @@ static int cups_mangle_printer_name(struct printer *pr,
 
 	while ((cups_check_printer(pr, printers, 0)) && count < 100) {
 		memset(pr->p_name, 0, name_len);
-		sprintf(pr->p_name, "%s#%2.2lu", name, count++);
+		sprintf(pr->p_name, "%s#%2.2lu", name, (unsigned long) count++);
 	}
 
 	if (count > 99)


### PR DESCRIPTION
Resolve gcc10 errors on 32 bit Linux, pertaining to long integers.
Also, removed one #pragma warn that was hindering compilation.