### PR TITLE
The atalkd daemon needs to run as a forking systemd service.

### DIFF
--- a/distrib/initscripts/atalkd.service.tmpl
+++ b/distrib/initscripts/atalkd.service.tmpl
@@ -3,7 +3,7 @@ Description=netatalk-classic AppleTalk protocol server for Macintosh clients
 After=network.target
 
 [Service]
-Type=simple
+Type=forking
 GuessMainPID=no
 ExecStart=:SBINDIR:/atalkd
 Restart=always


### PR DESCRIPTION
When run as a simple service, it gets stuck in an endless loop of systemd starting and stopping.