### PR TITLE
Fix the uninstall hook for systemd.

### DIFF
--- a/distrib/initscripts/Makefile.am
+++ b/distrib/initscripts/Makefile.am
@@ -66,8 +66,7 @@ install-data-hook:
 
 uninstall-startup:
 	-systemctl disable $(service_DATA)
-	rm -f $(DESTDIR)$(sysvdir)/$(sysv_SCRIPTS)	\
-		$(DESTDIR)$(servicedir)/$(service_DATA)
+	rm -f $(addprefix $(DESTDIR)$(servicedir)/, $(service_DATA))
 	-systemctl daemon-reload
 
 endif


### PR DESCRIPTION
- Removed the sysv line, since no such files are created with the systemd configuration (and it resolved to 'rm -f /' which is too close to disaster for comfort ;) )
- Used addprefix to expand the second line to a valid rm command.