### PR TITLE
Resolve gcc warnings to make afppassword compile with cracklib

### DIFF
--- a/bin/afppasswd/afppasswd.c
+++ b/bin/afppasswd/afppasswd.c
@@ -183,7 +183,7 @@ static int update_passwd(const char *path, const char *name, int flags)
 	password[PASSWDLEN] = '\0';
 #if defined(USE_CRACKLIB)
 	if (!(flags & OPT_NOCRACK)) {
-		if (passwd = FascistCheck(password, _PATH_CRACKLIB)) {
+		if ((passwd = (char *) FascistCheck(password, _PATH_CRACKLIB))) {
 			fprintf(stderr, "Error: %s\n", passwd);
 			err = -1;
 			goto update_done;


### PR DESCRIPTION
On Raspbian Bullseye, the requirements are:
```
$ apt install cracklib-runtime libcrack2-dev
$ update-cracklib
$ ls /var/cache/cracklib/
cracklib_dict.hwm  cracklib_dict.pwd  cracklib_dict.pwi  src-dicts
$ ./configure --with-cracklib=/var/cache/cracklib/cracklib_dict
$ make && make install
$ afppasswd
Enter OLD AFP password:
Enter NEW AFP password: # [enter 'password']
Error: it is based on a dictionary word
```