### PR TITLE
Backport upstream CVE patches + revert commit that broke adouble

### DIFF
--- a/etc/afpd/afp_options.c
+++ b/etc/afpd/afp_options.c
@@ -172,7 +172,7 @@ void afp_options_init(struct afp_options *options)
 	options->server_notif = 1;
 	options->authprintdir = NULL;
 	options->signatureopt = "auto";
-	options->umask = 0022;
+	options->umask = 0;
 #ifdef ADMIN_GRP
 	options->admingid = 0;
 #endif				/* ADMIN_GRP */

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -1290,7 +1290,7 @@ int getdirparams(const struct vol *vol,
 {
 	struct maccess ma;
 	struct adouble ad;
-	char *data, *l_nameoff = NULL, *utf_nameoff = NULL;
+	char *data, *l_nameoff = NULL, *utf_nameoff = NULL, *ade = NULL;
 	int bit = 0, isad = 0;
 	u_int32_t aint;
 	u_int16_t ashort;
@@ -1394,8 +1394,10 @@ int getdirparams(const struct vol *vol,
 
 		case DIRPBIT_FINFO:
 			if (isad) {
-				memcpy(data, ad_entry(&ad, ADEID_FINDERI),
-				       32);
+                ade = ad_entry(&ad, ADEID_FINDERI);
+                AFP_ASSERT(ade != NULL);
+
+                memcpy( data, ade, 32 );
 			} else {	/* no appledouble */
 				memset(data, 0, 32);
 				/* dot files are by default visible */
@@ -1600,7 +1602,7 @@ int setdirparams(struct vol *vol, struct path *path, u_int16_t d_bitmap,
 	struct utimbuf ut;
 	struct timeval tv;
 
-	char *upath;
+	char *upath, *ade = NULL;
 	struct dir *dir;
 	int bit, isad = 1;
 	int cdate = 0;
@@ -1770,6 +1772,8 @@ int setdirparams(struct vol *vol, struct path *path, u_int16_t d_bitmap,
 				fflags &= htons(~FINDERINFO_ISHARED);
 				memcpy(finder_buf + FINDERINFO_FRFLAGOFF, &fflags, sizeof(u_int16_t));
 				/* #2802236 end */
+                ade = ad_entry(&ad, ADEID_FINDERI);
+                AFP_ASSERT(ade != NULL);
 
 				if (dir->d_did == DIRDID_ROOT) {
 					/*
@@ -1780,15 +1784,10 @@ int setdirparams(struct vol *vol, struct path *path, u_int16_t d_bitmap,
 					 * behavior one sees when mounting above another mount
 					 * point.
 					 */
-					memcpy(ad_entry
-					       (&ad, ADEID_FINDERI),
-					       finder_buf, 10);
-					memcpy(ad_entry(&ad, ADEID_FINDERI)
-					       + 14, finder_buf + 14, 18);
-				} else {
-					memcpy(ad_entry
-					       (&ad, ADEID_FINDERI),
-					       finder_buf, 32);
+                    memcpy( ade, finder_buf, 10 );
+                    memcpy( ade + 14, finder_buf + 14, 18 );
+                } else {
+                    memcpy( ade, finder_buf, 32 );
 				}
 			}
 			break;

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -306,6 +306,7 @@ int getmetadata(struct vol *vol,
 {
 	char *data, *l_nameoff = NULL, *upath;
 	char *utf_nameoff = NULL;
+    char *ade = NULL;
 	int bit = 0;
 	u_int32_t aint;
 	cnid_t id = 0;
@@ -523,7 +524,10 @@ int getmetadata(struct vol *vol,
 			   <shirsch@adelphia.net> */
 		case FILPBIT_PDINFO:
 			if (adp) {
-				memcpy(fdType, ad_entry(adp, ADEID_FINDERI), 4);
+                ade = ad_entry(adp, ADEID_FINDERI);
+                AFP_ASSERT(ade != NULL);
+
+                memcpy(fdType, ade, 4);
 
 				if (memcmp(fdType, "TEXT", 4) == 0) {
 					achar = '\x04';
@@ -848,6 +852,7 @@ int setfilparams(struct vol *vol,
 	struct extmap *em;
 	int bit, isad = 1, err = AFP_OK;
 	char *upath;
+    char *ade = NULL;
 	u_int8_t achar, xyy[4];
 	u_int8_t *fdType = NULL;	/* "uninitialized, OK 310105" -- yeah, no */
 	u_int16_t ashort = 0;
@@ -1019,7 +1024,9 @@ int setfilparams(struct vol *vol,
 			ad_setdate(adp, AD_DATE_BACKUP, bdate);
 			break;
 		case FILPBIT_FINFO:
-			if (default_type(ad_entry(adp, ADEID_FINDERI))
+            ade = ad_entry(adp, ADEID_FINDERI);
+            AFP_ASSERT(ade != NULL);
+            if (default_type(ade)
 			    && (((em = getextmap(path->m_name)) &&
 				 !memcmp(finder_buf, em->em_type,
 					 sizeof(em->em_type))
@@ -1034,12 +1041,13 @@ int setfilparams(struct vol *vol,
 			    )) {
 				memcpy(finder_buf, ufinderi, 8);
 			}
-			memcpy(ad_entry(adp, ADEID_FINDERI), finder_buf,
-			       32);
+			memcpy(ade, finder_buf, 32);
 			break;
 		case FILPBIT_PDINFO:
-			memcpy(ad_entry(adp, ADEID_FINDERI), fdType, 4);
-			memcpy(ad_entry(adp, ADEID_FINDERI) + 4, "pdos", 4);
+            ade = ad_entry(adp, ADEID_FINDERI);
+            AFP_ASSERT(ade != NULL);
+			memcpy(ade, fdType, 4);
+			memcpy(ade + 4, "pdos", 4);
 			break;
 		default:
 			err = AFPERR_BITMAP;

--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -1121,6 +1121,28 @@ static int readvolfile(AFPObj * obj, struct afp_volume_name *p1, char *p2,
 		p1->mtime = st.st_mtime;
 	}
 
+	/* try putting a read lock on the volume file twice, sleep 1 second if first attempt fails */
+	int retries = 2;
+	while (1) {
+		if ((read_lock(fd, 0, SEEK_SET, 0)) != 0) {
+			retries--;
+			if (!retries) {
+				LOG(log_error, logtype_afpd,
+				    "readvolfile: can't lock volume file \"%s\"",
+				    path);
+				if (fclose(fp) != 0) {
+					LOG(log_error, logtype_afpd,
+					    "readvolfile: fclose: %s",
+					    strerror(errno));
+				}
+				return -1;
+			}
+			sleep(1);
+			continue;
+		}
+		break;
+	}
+
 	memset(default_options, 0, sizeof(default_options));
 
 	/* Enable some default options for all volumes */

--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -1423,6 +1423,7 @@ static int getvolparams(u_int16_t bitmap, struct vol *vol, struct stat *st,
 	VolSpace xbfree, xbtotal;	/* extended bytes */
 	char *data, *nameoff = NULL;
 	char *slash;
+    char *ade = NULL;
 
 	LOG(log_debug, logtype_afpd, "getvolparams: Volume '%s'",
 	    vol->v_localname);
@@ -1444,8 +1445,10 @@ static int getvolparams(u_int16_t bitmap, struct vol *vol, struct stat *st,
 			slash = vol->v_path;
 		if (ad_getentryoff(&ad, ADEID_NAME)) {
 			ad_setentrylen(&ad, ADEID_NAME, strlen(slash));
-			memcpy(ad_entry(&ad, ADEID_NAME), slash,
-			       ad_getentrylen(&ad, ADEID_NAME));
+            ade = ad_entry(&ad, ADEID_NAME);
+            AFP_ASSERT(ade != NULL);
+
+            memcpy(ade, slash, ad_getentrylen( &ad, ADEID_NAME ));
 		}
 		vol_setdate(vol->v_vid, &ad, st->st_mtime);
 		ad_flush(&ad);

--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -1121,28 +1121,6 @@ static int readvolfile(AFPObj * obj, struct afp_volume_name *p1, char *p2,
 		p1->mtime = st.st_mtime;
 	}
 
-	/* try putting a read lock on the volume file twice, sleep 1 second if first attempt fails */
-	int retries = 2;
-	while (1) {
-		if ((read_lock(fd, 0, SEEK_SET, 0)) != 0) {
-			retries--;
-			if (!retries) {
-				LOG(log_error, logtype_afpd,
-				    "readvolfile: can't lock volume file \"%s\"",
-				    path);
-				if (fclose(fp) != 0) {
-					LOG(log_error, logtype_afpd,
-					    "readvolfile: fclose: %s",
-					    strerror(errno));
-				}
-				return -1;
-			}
-			sleep(1);
-			continue;
-		}
-		break;
-	}
-
 	memset(default_options, 0, sizeof(default_options));
 
 	/* Enable some default options for all volumes */

--- a/etc/cnid_dbd/cmd_dbd_scanvol.c
+++ b/etc/cnid_dbd/cmd_dbd_scanvol.c
@@ -940,8 +940,13 @@ static cnid_t check_cnid(const char *name, cnid_t did, struct stat *st,
 						strerror(errno));
 					return CNID_INVALID;
 				}
-				ad_setid(&ad, st->st_dev, st->st_ino,
-					 db_cnid, did, stamp);
+                ret = ad_setid( &ad, st->st_dev, st->st_ino, db_cnid, did, stamp);
+                if (ret == -1) {
+                    dbd_log(LOGSTD, "Error setting new CNID, malformed adouble: '%s/%s'",
+                            cwdbuf, name);
+                    ad_close(&ad, ADFLAGS_HF);
+                    return CNID_INVALID;
+                }
 				ad_flush(&ad);
 				ad_close_metadata(&ad);
 			}

--- a/etc/papd/session.c
+++ b/etc/papd/session.c
@@ -61,7 +61,7 @@ int session(ATP atp, struct sockaddr_at *sat)
 	char cbuf[578];
 	int i, cc, timeout = 0, readpending = 0;
 	u_int16_t seq = 0, rseq = 1, netseq;
-	u_char readport;	/* uninitialized, OK 310105 */
+	u_char readport = 0;
 	char *start;
 	int linelength, lflength;
 

--- a/include/atalk/adouble.h
+++ b/include/atalk/adouble.h
@@ -254,6 +254,7 @@ struct adouble {
     int                 ad_m_namelen;
     struct adouble_fops *ad_ops;
     u_int16_t       ad_open_forks;      /* open forks (by others) */
+    size_t              valid_data_len;	   /* Bytes read into ad_data */
 
 #ifdef USE_MMAPPED_HEADERS
     char                *ad_data;
@@ -408,7 +409,6 @@ struct adouble_fops {
 #define ad_getentrylen(ad,eid)     ((ad)->ad_eid[(eid)].ade_len)
 #define ad_setentrylen(ad,eid,len) ((ad)->ad_eid[(eid)].ade_len = (len))
 #define ad_getentryoff(ad,eid)     ((ad)->ad_eid[(eid)].ade_off)
-#define ad_entry(ad,eid)           ((caddr_t)(ad)->ad_data + (ad)->ad_eid[(eid)].ade_off)
 
 #define ad_get_HF_flags(ad) ((ad)->ad_resource_fork.adf_flags)
 #define ad_get_MD_flags(ad) ((ad)->ad_md->adf_flags)
@@ -440,6 +440,7 @@ extern int ad_excl_lock     (struct adouble * /*adp*/, const u_int32_t /*eid*/);
 #define ad_unlock ad_fcntl_unlock
 
 /* ad_open.c */
+extern void *ad_entry     (const struct adouble *ad, int eid);
 extern int ad_setfuid     (const uid_t );
 extern uid_t ad_getfuid   (void );
 extern char *ad_dir       (const char *);

--- a/include/atalk/adouble.h
+++ b/include/atalk/adouble.h
@@ -254,7 +254,6 @@ struct adouble {
     int                 ad_m_namelen;
     struct adouble_fops *ad_ops;
     u_int16_t       ad_open_forks;      /* open forks (by others) */
-    size_t              valid_data_len;	   /* Bytes read into ad_data */
 
 #ifdef USE_MMAPPED_HEADERS
     char                *ad_data;
@@ -409,6 +408,7 @@ struct adouble_fops {
 #define ad_getentrylen(ad,eid)     ((ad)->ad_eid[(eid)].ade_len)
 #define ad_setentrylen(ad,eid,len) ((ad)->ad_eid[(eid)].ade_len = (len))
 #define ad_getentryoff(ad,eid)     ((ad)->ad_eid[(eid)].ade_off)
+#define ad_entry(ad,eid)           ((caddr_t)(ad)->ad_data + (ad)->ad_eid[(eid)].ade_off)
 
 #define ad_get_HF_flags(ad) ((ad)->ad_resource_fork.adf_flags)
 #define ad_get_MD_flags(ad) ((ad)->ad_md->adf_flags)
@@ -440,7 +440,6 @@ extern int ad_excl_lock     (struct adouble * /*adp*/, const u_int32_t /*eid*/);
 #define ad_unlock ad_fcntl_unlock
 
 /* ad_open.c */
-extern void *ad_entry     (const struct adouble *ad, int eid);
 extern int ad_setfuid     (const uid_t );
 extern uid_t ad_getfuid   (void );
 extern char *ad_dir       (const char *);

--- a/libatalk/adouble/ad_attr.c
+++ b/libatalk/adouble/ad_attr.c
@@ -1,7 +1,11 @@
 #include "config.h"
 
+#include <stdlib.h>
 #include <string.h>
+#include <atalk/util.h>
 #include <atalk/adouble.h>
+#include <atalk/cnid.h>
+#include <atalk/logger.h>
 
 #define FILEIOFF_ATTR 14
 #define AFPFILEIOFF_ATTR 2
@@ -15,28 +19,31 @@
 int ad_getattr(const struct adouble *ad, u_int16_t * attr)
 {
 	u_int16_t fflags;
+    char *ade = NULL;
 	*attr = 0;
 
 	if (ad->ad_version == AD_VERSION1) {
 		if (ad_getentryoff(ad, ADEID_FILEI)) {
-			memcpy(attr,
-			       ad_entry(ad, ADEID_FILEI) + FILEIOFF_ATTR,
-			       sizeof(u_int16_t));
+            ade = ad_entry(ad, ADEID_FILEI);
+            AFP_ASSERT(ade != NULL);
+
+            memcpy(attr, ade + FILEIOFF_ATTR, sizeof(u_int16_t));
 		}
 	}
 #if AD_VERSION == AD_VERSION2
 	else if (ad->ad_version == AD_VERSION2) {
 		if (ad_getentryoff(ad, ADEID_AFPFILEI)) {
-			memcpy(attr,
-			       ad_entry(ad,
-					ADEID_AFPFILEI) + AFPFILEIOFF_ATTR,
-			       2);
+            ade = ad_entry(ad, ADEID_AFPFILEI);
+            AFP_ASSERT(ade != NULL);
+
+            memcpy(attr, ade + AFPFILEIOFF_ATTR, 2);
 
 			/* Now get opaque flags from FinderInfo */
-			memcpy(&fflags,
-			       ad_entry(ad,
-					ADEID_FINDERI) +
-			       FINDERINFO_FRFLAGOFF, 2);
+            ade = ad_entry(ad, ADEID_FINDERI);
+            AFP_ASSERT(ade != NULL);
+
+            memcpy(&fflags, ade + FINDERINFO_FRFLAGOFF, 2);
+
 			if (fflags & htons(FINDERINFO_INVISIBLE))
 				*attr |= htons(ATTRBIT_INVISIBLE);
 			else
@@ -66,6 +73,7 @@ int ad_getattr(const struct adouble *ad, u_int16_t * attr)
 int ad_setattr(const struct adouble *ad, const u_int16_t attribute)
 {
 	uint16_t fflags;
+    char *adp = NULL;
 
 	/* we don't save open forks indicator */
 	u_int16_t attr = attribute & ~htons(ATTRBIT_DOPEN | ATTRBIT_ROPEN);
@@ -79,22 +87,26 @@ int ad_setattr(const struct adouble *ad, const u_int16_t attribute)
 
 	if (ad->ad_version == AD_VERSION1) {
 		if (ad_getentryoff(ad, ADEID_FILEI)) {
-			memcpy(ad_entry(ad, ADEID_FILEI) + FILEIOFF_ATTR,
-			       &attr, sizeof(attr));
+            adp = ad_entry(ad, ADEID_FILEI);
+            AFP_ASSERT(adp != NULL);
+
+            memcpy(adp + FILEIOFF_ATTR, &attr, sizeof(attr));
 		}
 	}
 #if AD_VERSION == AD_VERSION2
 	else if (ad->ad_version == AD_VERSION2) {
 		if (ad_getentryoff(ad, ADEID_AFPFILEI)
 		    && ad_getentryoff(ad, ADEID_FINDERI)) {
-			memcpy(ad_entry(ad, ADEID_AFPFILEI) +
-			       AFPFILEIOFF_ATTR, &attr, sizeof(attr));
+            adp = ad_entry(ad, ADEID_AFPFILEI);
+            AFP_ASSERT(adp != NULL);
+
+            memcpy(adp + AFPFILEIOFF_ATTR, &attr, sizeof(attr));
 
 			/* Now set opaque flags in FinderInfo too */
-			memcpy(&fflags,
-			       ad_entry(ad,
-					ADEID_FINDERI) +
-			       FINDERINFO_FRFLAGOFF, 2);
+            adp = ad_entry(ad, ADEID_FINDERI);
+            AFP_ASSERT(adp != NULL);
+
+            memcpy(&fflags, adp + FINDERINFO_FRFLAGOFF, 2);
 			if (attr & htons(ATTRBIT_INVISIBLE))
 				fflags |= htons(FINDERINFO_INVISIBLE);
 			else
@@ -108,8 +120,7 @@ int ad_setattr(const struct adouble *ad, const u_int16_t attribute)
 			} else
 				fflags &= htons(~FINDERINFO_ISHARED);
 
-			memcpy(ad_entry(ad, ADEID_FINDERI) +
-			       FINDERINFO_FRFLAGOFF, &fflags, 2);
+            memcpy(adp + FINDERINFO_FRFLAGOFF, &fflags, 2);
 		}
 	}
 #endif
@@ -122,50 +133,79 @@ int ad_setattr(const struct adouble *ad, const u_int16_t attribute)
 /* --------------
  * save file/folder ID in AppleDoubleV2 netatalk private parameters
  * return 1 if resource fork has been modified
+ * return -1 on error.
  */
 #if AD_VERSION == AD_VERSION2
 int ad_setid(struct adouble *adp, const dev_t dev, const ino_t ino,
 	     const u_int32_t id, const cnid_t did, const void *stamp)
 {
+    char *ade = NULL;
 	if ((adp->ad_flags == AD_VERSION2)
 	    && (adp->ad_options & ADVOL_CACHE)) {
 
 		/* ad_getid depends on this to detect presence of ALL entries */
 		ad_setentrylen(adp, ADEID_PRIVID, sizeof(id));
-		memcpy(ad_entry(adp, ADEID_PRIVID), &id, sizeof(id));
+        ade = ad_entry(adp, ADEID_PRIVID);
+        if (ade == NULL) {
+            LOG(log_warning, logtype_default, "ad_setid: failed to set ADEID_PRIVID\n");
+            return -1;
+        }
+        memcpy(ade, &id, sizeof(id));
 
 		ad_setentrylen(adp, ADEID_PRIVDEV, sizeof(dev_t));
 		if ((adp->ad_options & ADVOL_NODEV)) {
 			memset(ad_entry(adp, ADEID_PRIVDEV), 0,
 			       sizeof(dev_t));
 		} else {
-			memcpy(ad_entry(adp, ADEID_PRIVDEV), &dev,
-			       sizeof(dev_t));
+            ade = ad_entry(adp, ADEID_PRIVDEV);
+                if (ade == NULL) {
+                    LOG(log_warning, logtype_default, "ad_setid: failed to set ADEID_PRIVDEV\n");
+                    return -1;
+            }
+            memcpy(ade, &dev, sizeof(dev_t));
 		}
 
 		ad_setentrylen(adp, ADEID_PRIVINO, sizeof(ino_t));
-		memcpy(ad_entry(adp, ADEID_PRIVINO), &ino, sizeof(ino_t));
+        ade = ad_entry(adp, ADEID_PRIVINO);
+        if (ade == NULL) {
+            LOG(log_warning, logtype_default, "ad_setid: failed to set ADEID_PRIVINO\n");
+            return -1;
+        }
+        memcpy(ade, &ino, sizeof(ino_t));
 
 		ad_setentrylen(adp, ADEID_DID, sizeof(did));
-		memcpy(ad_entry(adp, ADEID_DID), &did, sizeof(did));
+        ade = ad_entry(adp, ADEID_DID);
+        if (ade == NULL) {
+            LOG(log_warning, logtype_default, "ad_setid: failed to set ADEID_DID\n");
+            return -1;
+        }
+        memcpy(ade, &did, sizeof(did));
 
 		ad_setentrylen(adp, ADEID_PRIVSYN, ADEDLEN_PRIVSYN);
-		memcpy(ad_entry(adp, ADEID_PRIVSYN), stamp,
-		       ADEDLEN_PRIVSYN);
+        ade = ad_entry(adp, ADEID_PRIVSYN);
+        if (ade == NULL) {
+            LOG(log_warning, logtype_default, "ad_setid: failed to set ADEID_PRIVSYN\n");
+            return -1;
+        }
+        memcpy(ade, stamp, ADEDLEN_PRIVSYN);
 		return 1;
 	}
 	return 0;
 }
 
 /* ----------------------------- */
+/*
+ * Retrieve stored file / folder. Callers should treat a return of CNID_INVALID (0) as an invalid value.
+ */
 u_int32_t ad_getid(struct adouble *adp, const dev_t st_dev,
 		   const ino_t st_ino, const cnid_t did, const void *stamp)
 {
 	u_int32_t aint = 0;
 	dev_t dev;
 	ino_t ino;
-	cnid_t a_did;
+	cnid_t a_did = 0;
 	char temp[ADEDLEN_PRIVSYN];
+    char *ade = NULL;
 
 	/* look in AD v2 header
 	 * note inode and device are opaques and not in network order
@@ -175,32 +215,61 @@ u_int32_t ad_getid(struct adouble *adp, const dev_t st_dev,
 	    && (adp->ad_md->adf_flags & O_RDWR)
 	    && (sizeof(dev_t) == ad_getentrylen(adp, ADEID_PRIVDEV))	/* One check to ensure ALL values are there */
 	    ) {
-		memcpy(&dev, ad_entry(adp, ADEID_PRIVDEV), sizeof(dev_t));
-		memcpy(&ino, ad_entry(adp, ADEID_PRIVINO), sizeof(ino_t));
-		memcpy(temp, ad_entry(adp, ADEID_PRIVSYN), sizeof(temp));
-		memcpy(&a_did, ad_entry(adp, ADEID_DID), sizeof(cnid_t));
+        ade = ad_entry(adp, ADEID_PRIVDEV);
+        if (ade == NULL) {
+            LOG(log_warning, logtype_default, "ad_getid: failed to retrieve ADEID_PRIVDEV\n");
+            return CNID_INVALID;
+        }
+        memcpy(&dev, ade, sizeof(dev_t));
+        ade = ad_entry(adp, ADEID_PRIVINO);
+        if (ade == NULL) {
+            LOG(log_warning, logtype_default, "ad_getid: failed to retrieve ADEID_PRIVNO\n");
+            return CNID_INVALID;
+        }
+        memcpy(&ino, ade, sizeof(ino_t));
+        ade = ad_entry(adp, ADEID_PRIVSYN);
+        if (ade == NULL) {
+            LOG(log_warning, logtype_default, "ad_getid: failed to retrieve ADEID_PRIVSYN\n");
+            return CNID_INVALID;
+        }
+        memcpy(temp, ade, sizeof(temp));
+        ade = ad_entry(adp, ADEID_DID);
+        if (ade == NULL) {
+            LOG(log_warning, logtype_default, "ad_getid: failed to retrieve ADEID_DID\n");
+            return CNID_INVALID;
+        }
+        memcpy(&a_did, ade, sizeof(cnid_t));
 
 		if (((adp->ad_options & ADVOL_NODEV) || dev == st_dev)
-		    && ino == st_ino && (!did || a_did == did)
+		    && ino == st_ino && (!did || a_did == 0 || a_did == did)
 		    && (memcmp(stamp, temp, sizeof(temp)) == 0)) {
-			memcpy(&aint, ad_entry(adp, ADEID_PRIVID),
-			       sizeof(aint));
+            ade = ad_entry(adp, ADEID_PRIVID);
+            if (ade == NULL) {
+                LOG(log_warning, logtype_default, "ad_getid: failed to retrieve ADEID_PRIVID\n");
+                return CNID_INVALID;
+            }
+            memcpy(&aint, ade, sizeof(aint));
 			return aint;
 		}
 	}
-	return 0;
+	return CNID_INVALID;
 }
 
 /* ----------------------------- */
 u_int32_t ad_forcegetid(struct adouble *adp)
 {
 	u_int32_t aint = 0;
+    char *ade = NULL;
 
 	if (adp && (adp->ad_options & ADVOL_CACHE)) {
-		memcpy(&aint, ad_entry(adp, ADEID_PRIVID), sizeof(aint));
+        ade = ad_entry(adp, ADEID_PRIVID);
+        if (ade == NULL) {
+            return CNID_INVALID;
+        }
+        memcpy(&aint, ade, sizeof(aint));
 		return aint;
 	}
-	return 0;
+    return CNID_INVALID;
 }
 #endif
 
@@ -210,11 +279,16 @@ u_int32_t ad_forcegetid(struct adouble *adp)
 int ad_setname(struct adouble *ad, const char *path)
 {
 	int len;
+    char *ade = NULL;
 	if ((len = strlen(path)) > ADEDLEN_NAME)
 		len = ADEDLEN_NAME;
 	if (path && ad_getentryoff(ad, ADEID_NAME)) {
 		ad_setentrylen(ad, ADEID_NAME, len);
-		memcpy(ad_entry(ad, ADEID_NAME), path, len);
+        ade = ad_entry(ad, ADEID_NAME);
+        if (ade == NULL) {
+            return -1;
+        }
+        memcpy(ade, path, len);
 		return 1;
 	}
 	return 0;

--- a/libatalk/adouble/ad_date.c
+++ b/libatalk/adouble/ad_date.c
@@ -6,6 +6,7 @@
 int ad_setdate(struct adouble *ad, unsigned int dateoff, u_int32_t date)
 {
 	int xlate = (dateoff & AD_DATE_UNIX);
+    char *ade = NULL;
 
 	dateoff &= AD_DATE_MASK;
 	if (xlate)
@@ -18,8 +19,11 @@ int ad_setdate(struct adouble *ad, unsigned int dateoff, u_int32_t date)
 
 		if (dateoff > AD_DATE_BACKUP)
 			return -1;
-		memcpy(ad_entry(ad, ADEID_FILEI) + dateoff, &date,
-		       sizeof(date));
+        ade = ad_entry(ad, ADEID_FILEI);
+        if (ade == NULL) {
+            return -1;
+        }
+        memcpy(ade + dateoff, &date, sizeof(date));
 
 	} else if (ad->ad_version == AD_VERSION2) {
 		if (!ad_getentryoff(ad, ADEID_FILEDATESI))
@@ -27,8 +31,12 @@ int ad_setdate(struct adouble *ad, unsigned int dateoff, u_int32_t date)
 
 		if (dateoff > AD_DATE_ACCESS)
 			return -1;
-		memcpy(ad_entry(ad, ADEID_FILEDATESI) + dateoff, &date,
-		       sizeof(date));
+
+        ade = ad_entry(ad, ADEID_FILEDATESI);
+        if (ade == NULL) {
+            return -1;
+        }
+        memcpy(ade + dateoff, &date, sizeof(date));
 
 	} else
 		return -1;
@@ -40,6 +48,7 @@ int ad_getdate(const struct adouble *ad,
 	       unsigned int dateoff, u_int32_t * date)
 {
 	int xlate = (dateoff & AD_DATE_UNIX);
+    char *ade = NULL;
 
 	dateoff &= AD_DATE_MASK;
 	if (ad->ad_version == AD_VERSION1) {
@@ -47,8 +56,12 @@ int ad_getdate(const struct adouble *ad,
 			return -1;
 		if (!ad_getentryoff(ad, ADEID_FILEI))
 			return -1;
-		memcpy(date, ad_entry(ad, ADEID_FILEI) + dateoff,
-		       sizeof(u_int32_t));
+
+        ade = ad_entry(ad, ADEID_FILEI);
+        if (ade == NULL) {
+            return -1;
+        }
+        memcpy(date, ade + dateoff, sizeof(u_int32_t));
 
 	} else if (ad->ad_version == AD_VERSION2) {
 		if (!ad_getentryoff(ad, ADEID_FILEDATESI))
@@ -56,8 +69,12 @@ int ad_getdate(const struct adouble *ad,
 
 		if (dateoff > AD_DATE_ACCESS)
 			return -1;
-		memcpy(date, ad_entry(ad, ADEID_FILEDATESI) + dateoff,
-		       sizeof(u_int32_t));
+
+        ade = ad_entry(ad, ADEID_FILEDATESI);
+        if (ade == NULL) {
+            return -1;
+        }
+        memcpy(date, ade + dateoff, sizeof(uint32_t));
 
 	} else
 		return -1;

--- a/libatalk/adouble/ad_open.c
+++ b/libatalk/adouble/ad_open.c
@@ -543,7 +543,6 @@ static int parse_entries(struct adouble *ad, u_int16_t nentries,
 		}
 	}
 
-	ad->valid_data_len = valid_data_len;
 	return 0;
 }
 
@@ -800,122 +799,6 @@ static int ad_header_sfm_read(struct adouble *ad, struct stat *hst)
 	}
 
 	return 0;
-}
-
-/*
- * All entries besides FinderInfo and resource fork must fit into the
- * buffer. FinderInfo is special as it may be larger then the default 32 bytes
- * if it contains marshalled xattrs, which we will fixup that in
- * ad_convert(). The first 32 bytes however must also be part of the buffer.
- *
- * The resource fork is never accessed directly by the ad_data buf.
- */
-static bool ad_entry_check_size(uint32_t eid,
-				size_t bufsize,
-				uint32_t off,
-				uint32_t got_len)
-{
-	struct {
-		off_t expected_len;
-		bool fixed_size;
-		bool minimum_size;
-	} ad_checks[] = {
-		[ADEID_DFORK] = {-1, false, false}, /* not applicable */
-		[ADEID_RFORK] = {-1, false, false}, /* no limit */
-		[ADEID_NAME] = {ADEDLEN_NAME, false, false},
-		[ADEID_COMMENT] = {ADEDLEN_COMMENT, false, false},
-		[ADEID_ICONBW] = {ADEDLEN_ICONBW, true, false},
-		[ADEID_ICONCOL] = {ADEDLEN_ICONCOL, false, false},
-		[ADEID_FILEI] = {ADEDLEN_FILEI, true, false},
-		[ADEID_FILEDATESI] = {ADEDLEN_FILEDATESI, true, false},
-		[ADEID_FINDERI] = {ADEDLEN_FINDERI, false, true},
-		[ADEID_MACFILEI] = {ADEDLEN_MACFILEI, true, false},
-		[ADEID_PRODOSFILEI] = {ADEDLEN_PRODOSFILEI, true, false},
-		[ADEID_MSDOSFILEI] = {ADEDLEN_MSDOSFILEI, true, false},
-		[ADEID_SHORTNAME] = {ADEDLEN_SHORTNAME, false, false},
-		[ADEID_AFPFILEI] = {ADEDLEN_AFPFILEI, true, false},
-		[ADEID_DID] = {ADEDLEN_DID, true, false},
-		[ADEID_PRIVDEV] = {ADEDLEN_PRIVDEV, true, false},
-		[ADEID_PRIVINO] = {ADEDLEN_PRIVINO, true, false},
-		[ADEID_PRIVSYN] = {ADEDLEN_PRIVSYN, true, false},
-		[ADEID_PRIVID] = {ADEDLEN_PRIVID, true, false},
-	};
-    uint32_t required_len;
-
-	if (eid >= ADEID_MAX) {
-		return false;
-	}
-	if (got_len == 0) {
-		/* Entry present, but empty, allow */
-		return true;
-	}
-	if (ad_checks[eid].expected_len == 0) {
-		/*
-		 * Shouldn't happen: implicitly initialized to zero because
-		 * explicit initializer missing.
-		 */
-		return false;
-	}
-	if (ad_checks[eid].expected_len == -1) {
-		/* Unused or no limit */
-		return true;
-	}
-	if (ad_checks[eid].fixed_size) {
-		if (ad_checks[eid].expected_len != got_len) {
-			/* Wrong size fo fixed size entry. */
-			return false;
-		}
-        required_len = got_len;
-	} else {
-		if (ad_checks[eid].minimum_size) {
-			if (got_len < ad_checks[eid].expected_len) {
-				/*
-				 * Too small for variable sized entry with
-				 * minimum size.
-				 */
-				return false;
-			}
-        required_len = got_len;
-		} else {
-			if (got_len > ad_checks[eid].expected_len) {
-				/* Too big for variable sized entry. */
-				return false;
-			}
-            /*
-             * Expect the buffer to provide enough room for the maximum possible
-             * size.
-             */
-            required_len = ad_checks[eid].expected_len;
-		}
-	}
-	if (off + required_len < off) {
-		/* wrap around */
-		return false;
-	}
-	if (off + required_len > bufsize) {
-		/* overflow */
-		return false;
-	}
-	return true;
-}
-
-void *ad_entry(const struct adouble *ad, int eid)
-{
-	size_t bufsize = ad->valid_data_len;
-	off_t off = ad_getentryoff(ad, eid);
-	size_t len = ad_getentrylen(ad, eid);
-	bool valid;
-
-	valid = ad_entry_check_size(eid, bufsize, off, len);
-	if (!valid) {
-		return NULL;
-	}
-
-	if (off == 0 || len == 0) {
-		return NULL;
-	}
-
-	return ((struct adouble *)ad)->ad_data + off;
 }
 
 /* ---------------------------------------

--- a/libatalk/adouble/ad_open.c
+++ b/libatalk/adouble/ad_open.c
@@ -543,6 +543,7 @@ static int parse_entries(struct adouble *ad, u_int16_t nentries,
 		}
 	}
 
+	ad->valid_data_len = valid_data_len;
 	return 0;
 }
 
@@ -799,6 +800,122 @@ static int ad_header_sfm_read(struct adouble *ad, struct stat *hst)
 	}
 
 	return 0;
+}
+
+/*
+ * All entries besides FinderInfo and resource fork must fit into the
+ * buffer. FinderInfo is special as it may be larger then the default 32 bytes
+ * if it contains marshalled xattrs, which we will fixup that in
+ * ad_convert(). The first 32 bytes however must also be part of the buffer.
+ *
+ * The resource fork is never accessed directly by the ad_data buf.
+ */
+static bool ad_entry_check_size(uint32_t eid,
+				size_t bufsize,
+				uint32_t off,
+				uint32_t got_len)
+{
+	struct {
+		off_t expected_len;
+		bool fixed_size;
+		bool minimum_size;
+	} ad_checks[] = {
+		[ADEID_DFORK] = {-1, false, false}, /* not applicable */
+		[ADEID_RFORK] = {-1, false, false}, /* no limit */
+		[ADEID_NAME] = {ADEDLEN_NAME, false, false},
+		[ADEID_COMMENT] = {ADEDLEN_COMMENT, false, false},
+		[ADEID_ICONBW] = {ADEDLEN_ICONBW, true, false},
+		[ADEID_ICONCOL] = {ADEDLEN_ICONCOL, false, false},
+		[ADEID_FILEI] = {ADEDLEN_FILEI, true, false},
+		[ADEID_FILEDATESI] = {ADEDLEN_FILEDATESI, true, false},
+		[ADEID_FINDERI] = {ADEDLEN_FINDERI, false, true},
+		[ADEID_MACFILEI] = {ADEDLEN_MACFILEI, true, false},
+		[ADEID_PRODOSFILEI] = {ADEDLEN_PRODOSFILEI, true, false},
+		[ADEID_MSDOSFILEI] = {ADEDLEN_MSDOSFILEI, true, false},
+		[ADEID_SHORTNAME] = {ADEDLEN_SHORTNAME, false, false},
+		[ADEID_AFPFILEI] = {ADEDLEN_AFPFILEI, true, false},
+		[ADEID_DID] = {ADEDLEN_DID, true, false},
+		[ADEID_PRIVDEV] = {ADEDLEN_PRIVDEV, true, false},
+		[ADEID_PRIVINO] = {ADEDLEN_PRIVINO, true, false},
+		[ADEID_PRIVSYN] = {ADEDLEN_PRIVSYN, true, false},
+		[ADEID_PRIVID] = {ADEDLEN_PRIVID, true, false},
+	};
+    uint32_t required_len;
+
+	if (eid >= ADEID_MAX) {
+		return false;
+	}
+	if (got_len == 0) {
+		/* Entry present, but empty, allow */
+		return true;
+	}
+	if (ad_checks[eid].expected_len == 0) {
+		/*
+		 * Shouldn't happen: implicitly initialized to zero because
+		 * explicit initializer missing.
+		 */
+		return false;
+	}
+	if (ad_checks[eid].expected_len == -1) {
+		/* Unused or no limit */
+		return true;
+	}
+	if (ad_checks[eid].fixed_size) {
+		if (ad_checks[eid].expected_len != got_len) {
+			/* Wrong size fo fixed size entry. */
+			return false;
+		}
+        required_len = got_len;
+	} else {
+		if (ad_checks[eid].minimum_size) {
+			if (got_len < ad_checks[eid].expected_len) {
+				/*
+				 * Too small for variable sized entry with
+				 * minimum size.
+				 */
+				return false;
+			}
+        required_len = got_len;
+		} else {
+			if (got_len > ad_checks[eid].expected_len) {
+				/* Too big for variable sized entry. */
+				return false;
+			}
+            /*
+             * Expect the buffer to provide enough room for the maximum possible
+             * size.
+             */
+            required_len = ad_checks[eid].expected_len;
+		}
+	}
+	if (off + required_len < off) {
+		/* wrap around */
+		return false;
+	}
+	if (off + required_len > bufsize) {
+		/* overflow */
+		return false;
+	}
+	return true;
+}
+
+void *ad_entry(const struct adouble *ad, int eid)
+{
+	size_t bufsize = ad->valid_data_len;
+	off_t off = ad_getentryoff(ad, eid);
+	size_t len = ad_getentrylen(ad, eid);
+	bool valid;
+
+	valid = ad_entry_check_size(eid, bufsize, off, len);
+	if (!valid) {
+		return NULL;
+	}
+
+	if (off == 0 || len == 0) {
+		return NULL;
+	}
+
+	return ((struct adouble *)ad)->ad_data + off;
 }
 
 /* ---------------------------------------

--- a/libatalk/adouble/ad_open.c
+++ b/libatalk/adouble/ad_open.c
@@ -510,14 +510,14 @@ static int ad_convert(struct adouble *ad, const char *path)
 }
 #endif				/* AD_VERSION == AD_VERSION2 */
 
-/* -------------------------------------
-   read in the entries
-*/
-static void parse_entries(struct adouble *ad, char *buf,
-			  u_int16_t nentries)
+/**
+ * Read an AppleDouble buffer, returns 0 on success, -1 if an entry was malformatted
+ **/
+static int parse_entries(struct adouble *ad, u_int16_t nentries,
+                          size_t valid_data_len)
 {
 	u_int32_t eid, len, off;
-	int warning = 0;
+	char *buf = ad->ad_data + AD_HEADER_LEN;
 
 	/* now, read in the entry bits */
 	for (; nentries > 0; nentries--) {
@@ -532,17 +532,18 @@ static void parse_entries(struct adouble *ad, char *buf,
 		buf += sizeof(len);
 
 		if (eid && eid < ADEID_MAX && off < sizeof(ad->ad_data) &&
-		    (off + len <= sizeof(ad->ad_data)
-		     || eid == ADEID_RFORK)) {
+		   (off + len <= valid_data_len || eid == ADEID_RFORK)) {
 			ad->ad_eid[eid].ade_off = off;
 			ad->ad_eid[eid].ade_len = len;
-		} else if (!warning) {
-			warning = 1;
-			LOG(log_debug, logtype_default,
-			    "ad_refresh: nentries %hd  eid %d", nentries,
-			    eid);
+		} else {
+			LOG(log_warning, logtype_default,
+				"ad_refresh: nentries %hd  eid %d",
+				nentries, eid );
+			return -1;
 		}
 	}
+
+	return 0;
 }
 
 
@@ -557,7 +558,6 @@ static int ad_header_read(struct adouble *ad, struct stat *hst)
 {
 	char *buf = ad->ad_data;
 	u_int16_t nentries;
-	int len;
 	ssize_t header_len;
 	static int warning = 0;
 	struct stat st;
@@ -618,26 +618,26 @@ static int ad_header_read(struct adouble *ad, struct stat *hst)
 	memcpy(ad->ad_filler, buf + ADEDOFF_FILLER, sizeof(ad->ad_filler));
 	memcpy(&nentries, buf + ADEDOFF_NENTRIES, sizeof(nentries));
 	nentries = ntohs(nentries);
-
-	/* read in all the entry headers. if we have more than the
-	 * maximum, just hope that the rfork is specified early on. */
-	len = nentries * AD_ENTRY_LEN;
-
-	if (len + AD_HEADER_LEN > sizeof(ad->ad_data))
-		len = sizeof(ad->ad_data) - AD_HEADER_LEN;
-
-	buf += AD_HEADER_LEN;
-	if (len > header_len - AD_HEADER_LEN) {
-		LOG(log_debug, logtype_default,
-		    "ad_header_read: can't read entry info.");
+	if (nentries > 16) {
+		LOG(log_error, logtype_default, "ad_open: too many entries: %d",
+				nentries);
 		errno = EIO;
 		return -1;
 	}
 
-	/* figure out all of the entry offsets and lengths. if we aren't
-	 * able to read a resource fork entry, bail. */
-	nentries = len / AD_ENTRY_LEN;
-	parse_entries(ad, buf, nentries);
+	if ((nentries * AD_ENTRY_LEN) + AD_HEADER_LEN > header_len) {
+		LOG(log_error, logtype_default, "ad_header_read: too many entries: %zd",
+				header_len);
+		errno = EIO;
+		return -1;
+	}
+
+	if (parse_entries(ad, nentries, header_len) != 0) {
+		LOG(log_warning, logtype_default,
+				"ad_header_read(): malformed AppleDouble");
+		errno = EIO;
+		return -1;
+	}
 	if (!ad_getentryoff(ad, ADEID_RFORK)
 	    || (ad_getentryoff(ad, ADEID_RFORK) > sizeof(ad->ad_data))
 	    ) {

--- a/libatalk/adouble/ad_open.c
+++ b/libatalk/adouble/ad_open.c
@@ -165,22 +165,22 @@ static u_int32_t get_eid(struct adouble *ad, u_int32_t eid)
 
 #define DISK_EID(ad, a) get_eid(ad, a)
 
-static const struct entry entry_order2[ADEID_NUM_V2 + 1] = {
-	{ ADEID_NAME, ADEDOFF_NAME_V2, ADEDLEN_INIT },
-	{ ADEID_COMMENT, ADEDOFF_COMMENT_V2, ADEDLEN_INIT },
-	{ ADEID_FILEDATESI, ADEDOFF_FILEDATESI, ADEDLEN_FILEDATESI },
-	{ ADEID_FINDERI, ADEDOFF_FINDERI_V2, ADEDLEN_FINDERI },
-	{ ADEID_DID, ADEDOFF_DID, ADEDLEN_DID },
-	{ ADEID_AFPFILEI, ADEDOFF_AFPFILEI, ADEDLEN_AFPFILEI },
-	{ ADEID_SHORTNAME, ADEDOFF_SHORTNAME, ADEDLEN_INIT },
-	{ ADEID_PRODOSFILEI, ADEDOFF_PRODOSFILEI, ADEDLEN_PRODOSFILEI },
-	{ ADEID_PRIVDEV, ADEDOFF_PRIVDEV, ADEDLEN_INIT },
-	{ ADEID_PRIVINO, ADEDOFF_PRIVINO, ADEDLEN_INIT },
-	{ ADEID_PRIVSYN, ADEDOFF_PRIVSYN, ADEDLEN_INIT },
-	{ ADEID_PRIVID, ADEDOFF_PRIVID, ADEDLEN_INIT },
-	{ ADEID_RFORK, ADEDOFF_RFORK_V2, ADEDLEN_INIT },
+static const struct entry entry_order2[ADEID_NUM_V2 +1] = {
+    { ADEID_NAME, ADEDOFF_NAME_V2, ADEDLEN_INIT },
+    { ADEID_COMMENT, ADEDOFF_COMMENT_V2, ADEDLEN_COMMENT },
+    { ADEID_FILEDATESI, ADEDOFF_FILEDATESI, ADEDLEN_FILEDATESI },
+    { ADEID_FINDERI, ADEDOFF_FINDERI_V2, ADEDLEN_FINDERI },
+    { ADEID_DID, ADEDOFF_DID, ADEDLEN_DID },
+    { ADEID_AFPFILEI, ADEDOFF_AFPFILEI, ADEDLEN_AFPFILEI },
+    { ADEID_SHORTNAME, ADEDOFF_SHORTNAME, ADEDLEN_INIT },
+    { ADEID_PRODOSFILEI, ADEDOFF_PRODOSFILEI, ADEDLEN_PRODOSFILEI },
+    { ADEID_PRIVDEV,     ADEDOFF_PRIVDEV, ADEDLEN_PRIVDEV },
+    { ADEID_PRIVINO,     ADEDOFF_PRIVINO, ADEDLEN_PRIVINO },
+    { ADEID_PRIVSYN,     ADEDOFF_PRIVSYN, ADEDLEN_PRIVSYN },
+    { ADEID_PRIVID,     ADEDOFF_PRIVID, ADEDLEN_PRIVID },
+    { ADEID_RFORK, ADEDOFF_RFORK_V2, ADEDLEN_INIT },
 
-	{ 0, 0, 0 }
+    {0, 0, 0}
 };
 
 /* OS X adouble finder info and resource fork only
@@ -1806,6 +1806,7 @@ static int new_rfork(const char *path, struct adouble *ad, int adflags)
 	const struct entry *eid;
 	u_int16_t ashort;
 	struct stat st;
+    char *ade = NULL;
 
 	ad->ad_magic = AD_MAGIC;
 	ad->ad_version = ad->ad_flags & 0x0f0000;
@@ -1840,8 +1841,11 @@ static int new_rfork(const char *path, struct adouble *ad, int adflags)
 		ashort = htons(ATTRBIT_INVISIBLE);
 		ad_setattr(ad, ashort);
 		ashort = htons(FINDERINFO_INVISIBLE);
-		memcpy(ad_entry(ad, ADEID_FINDERI) + FINDERINFO_FRFLAGOFF,
-		       &ashort, sizeof(ashort));
+        ade = ad_entry(ad, ADEID_FINDERI);
+        if (ade == NULL) {
+            return -1;
+        }
+        memcpy(ade + FINDERINFO_FRFLAGOFF, &ashort, sizeof(ashort));
 	}
 
 	if (ostat(path, &st, ad_get_syml_opt(ad)) < 0) {


### PR DESCRIPTION
Two consolidated CVE patches from upstream Netatalk, adapted for 2.2 codebase. Should bring us up to par with the latest master over there.

Also, reverting https://github.com/christopherkobayashi/netatalk-classic/commit/0cd8f92ab72ad8441e75b42940343b47238dae71 which turns out to have been the cause of https://github.com/christopherkobayashi/netatalk-classic/issues/17. Not sure if you're happy about going back to an "insane" value there... (I previously had another culprit that was subsequently double-reverted.)